### PR TITLE
Potential fix for code scanning alert no. 15: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/app/utils/logging_config.py
+++ b/src/app/utils/logging_config.py
@@ -109,7 +109,7 @@ def sanitize_file_path(file_path: str) -> str:
     directory = os.path.dirname(file_path)
     
     # Create a hash of the directory for debugging without exposing the path
-    dir_hash = hashlib.md5(directory.encode()).hexdigest()[:8]
+    dir_hash = hashlib.sha256(directory.encode()).hexdigest()[:8]
     
     return f"[DIR_{dir_hash}]/{filename}"
 


### PR DESCRIPTION
Potential fix for [https://github.com/dj-urg/data-mirroring/security/code-scanning/15](https://github.com/dj-urg/data-mirroring/security/code-scanning/15)

To fix this issue, the hash function in `sanitize_file_path` should be replaced with a strong, modern cryptographic digest, such as SHA-256 or SHA-512 from the hashlib library. Since only the first 8 characters of the hex digest are used for brevity in logs, switching to SHA-256 (or SHA-512) will keep the output equally usable, but cryptographically stronger. Only the code in src/app/utils/logging_config.py (lines in `sanitize_file_path`, specifically line 112) needs to be changed, and no external dependencies are required. If `hashlib` is already imported, no further imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
